### PR TITLE
allow an auth token to be used

### DIFF
--- a/.github/workflows/update_licenses.yaml
+++ b/.github/workflows/update_licenses.yaml
@@ -18,23 +18,13 @@ jobs:
       uses: ./
       with:
         version: '2.x'
+        github_token: ${{ secrets.GITHUB_TOKEN }}
 
     - run: licensed cache
-    - name: Push cached file updates
-      run: |
-        git config --global user.name "github/licensed"
-        git config --global user.email "licensed@github.com"
-        git remote set-url origin "https://${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
-        BRANCH="$(echo "$GITHUB_REF" | sed 's,refs/heads/\(.*\),\1,')"
-
-        git checkout "$BRANCH"
-
-        git add .licenses
-        if ! git diff-index --quiet HEAD -- .licenses; then
-          git commit -m "Auto-update cached data"
-          git push --set-upstream origin "$BRANCH"
-        fi
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - uses: jonabc/licensed-ci@v1
+      with:
+        workflow: branch
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        cleanup_on_success: 'true'
 
     - run: licensed status

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # setup-licensed
 
-Set up [github/licensed](https://github.com/github/licensed) for use in actions.  Installs an executable for the specified `version` input and target platform.
+Set up [github/licensed](https://github.com/github/licensed) for use in actions by installing an executable for the specified `version` input and target platform.
 
-The action will fail if an licensed package isn't available for the specified version and target platform.  Licensed is currently supported on macOS and linux platforms.
+The action will fail if a licensed package isn't available for the specified version and target platform.  Licensed is currently supported on macOS and linux platforms.
 
 **Note**: this action will overwrite any version of the github/licensed executable already installed at the `install-dir` input.
 
@@ -18,6 +18,7 @@ steps:
   with:
     version: '2.x' # required: must satisfy semver.validRange
     install-dir: /path/to/install/at # optional: defaults to /usr/local/bin
+    github_token: # optional: allows users to make authenticated requests to GitHub's APIs
 - run: npm install # install dependencies in local environment
 - run: licensed list
 ```

--- a/action.yml
+++ b/action.yml
@@ -2,8 +2,11 @@ name: 'Setup github/licensed'
 description: 'Setup github/licensed for use in GitHub Actions workflows'
 branding:
   icon: check
-  color: green  
+  color: green
 inputs:
+  github_token:
+    description: 'Authentication token to use with the GitHub API'
+    required: false
   version:
     description: 'The github/licensed version to install'
     required: true

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,6 @@
 const core = require('@actions/core');
 const io = require('@actions/io');
+const Octokit = require('@octokit/rest');
 const os = require('os');
 const semver = require('semver');
 
@@ -9,13 +10,16 @@ async function run() {
   try {
     const version = core.getInput('version', { required: true });
     const installDir = core.getInput('install-dir', { required: true });
+    const token = core.getInput('github_token', { required: false });
     const platform = os.platform();
+
+    const github = new Octokit({ auth: token });
 
     if (!semver.validRange(version)) {
       throw new Error(`${version} is not a valid semantic version input`);
     }
 
-    const releases = await utils.getReleases();
+    const releases = await utils.getReleases(github);
     const releaseForVersion = await utils.findReleaseForVersion(releases, version);
     if (!releaseForVersion) {
       throw new Error(`github/licensed (${version}) release was not found`);
@@ -27,7 +31,7 @@ async function run() {
     }
 
     await io.mkdirP(installDir);
-    await utils.installLicensedFromReleaseAsset(licensedReleaseAsset, installDir);
+    await utils.installLicensedFromReleaseAsset(github, licensedReleaseAsset, installDir);
 
     if (!process.env['PATH'].includes(installDir)) {
       core.addPath(installDir);

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -2,14 +2,11 @@ const { exec } = require('@actions/exec');
 const io = require('@actions/io');
 let fs = require('fs');
 fs = { constants: fs.constants, ...fs.promises };
-const Octokit = require('@octokit/rest');
 const path = require('path');
 const os = require('os');
 const semver = require('semver');
 
-const github = new Octokit();
-
-async function getReleases() {
+async function getReleases(github) {
   const { data } = await github.repos.listReleases({
     owner: 'github',
     repo: 'licensed'
@@ -38,7 +35,7 @@ function findReleaseAssetForPlatform(release, platform) {
                        .find((asset) => asset.name.includes(platform));
 }
 
-async function _downloadLicensedArchive(asset) {
+async function _downloadLicensedArchive(github, asset) {
   const options = github.repos.getReleaseAsset.endpoint.merge({
     headers: {
        Accept: "application/octet-stream"
@@ -72,8 +69,8 @@ async function _extractLicensedArchive(archive, installDir) {
   }
 }
 
-async function installLicensedFromReleaseAsset(asset, installDir) {
-  const archivePath = await _downloadLicensedArchive(asset);
+async function installLicensedFromReleaseAsset(github, asset, installDir) {
+  const archivePath = await _downloadLicensedArchive(github, asset);
   await _extractLicensedArchive(archivePath, installDir);
 }
 

--- a/tests/utils.test.js
+++ b/tests/utils.test.js
@@ -1,9 +1,12 @@
 const fs = require('fs').promises;
 const nock = require('nock');
+const Octokit = require('@octokit/rest');
 const path = require('path');
 
 const utils = require('../lib/utils');
 const releases = require('./fixtures/releases.json');
+
+const github = new Octokit();
 
 describe('getReleases', () => {
   beforeEach(() => {
@@ -13,11 +16,11 @@ describe('getReleases', () => {
   });
 
   it('lists releases from github/licensed', () => {
-    return expect(utils.getReleases()).resolves.toBeInstanceOf(Array);
+    return expect(utils.getReleases(github)).resolves.toBeInstanceOf(Array);
   });
 
   it('filters releases without any assets', async () => {
-    const releases = await utils.getReleases();
+    const releases = await utils.getReleases(github);
     const release = releases.find((release) => release.tag_name === '2.3.1');
     expect(release).toBeUndefined();
   })
@@ -95,7 +98,7 @@ describe('installLicensed', () => {
       .get(`/repos/github/licensed/releases/assets/${asset.id}`)
       .replyWithFile(200, archiveFixture, { 'Content-Type': 'application/octet-stream' });
 
-    await utils.installLicensedFromReleaseAsset(asset, path.dirname(licensed));
+    await utils.installLicensedFromReleaseAsset(github, asset, path.dirname(licensed));
     await fs.access(licensed);
   });
 });


### PR DESCRIPTION
Fixes https://github.com/jonabc/setup-licensed/issues/6, for now at least 😂 

Adds `github_token` as an input and uses it when creating the octokit client.  This should help with some rare cases where unauthenticated requests were being rate limited.