### PR TITLE
Update README and actions for licensed v4 release

### DIFF
--- a/.github/workflows/licensed-ci.yaml
+++ b/.github/workflows/licensed-ci.yaml
@@ -44,7 +44,7 @@ jobs:
     # run licensed-ci to check and update licenses
     - uses: jonabc/licensed-ci@v1
       with:
-        workflow: push-for-bots
+        workflow: push_for_bots
         dependabot_skip: 'true'
         github_token: ${{ secrets.GITHUB_TOKEN }}
         cleanup_on_success: 'true'

--- a/.github/workflows/licensed-ci.yaml
+++ b/.github/workflows/licensed-ci.yaml
@@ -30,6 +30,8 @@ jobs:
         node-version: 18
 
     - uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: '3.0'
 
     # install and run this action
     - run: npm install --production --ignore-scripts

--- a/.github/workflows/licensed-ci.yaml
+++ b/.github/workflows/licensed-ci.yaml
@@ -31,7 +31,7 @@ jobs:
 
     - uses: ruby/setup-ruby@v1
       with:
-        ruby-version: '3.0'
+        ruby-version: ruby
 
     # install and run this action
     - run: npm install --production --ignore-scripts

--- a/.github/workflows/licensed-ci.yaml
+++ b/.github/workflows/licensed-ci.yaml
@@ -23,20 +23,26 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
+
+    # setup action requirements
+    - uses: actions/setup-node@v3
       with:
-        ref: ${{github.ref}} # checkout branch not SHA
-        fetch-depth: 0
+        node-version: 18
 
+    - uses: ruby/setup-ruby@v1
+
+    # install and run this action
     - run: npm install --production --ignore-scripts
-
     - name: Run setup-licensed
       uses: ./
       with:
-        version: '3.x'
+        version: '4.x'
         github_token: ${{ secrets.GITHUB_TOKEN }}
 
+    # run licensed-ci to check and update licenses
     - uses: jonabc/licensed-ci@v1
       with:
-        workflow: branch
+        workflow: push-for-bots
+        dependabot_skip: 'true'
         github_token: ${{ secrets.GITHUB_TOKEN }}
         cleanup_on_success: 'true'

--- a/.github/workflows/test-action-run.yml
+++ b/.github/workflows/test-action-run.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Run setup-licensed
         uses: ./
         with:
-          version: '3.x'
+          version: '4.x'
 
   exe:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -1,10 +1,18 @@
 # setup-licensed
 
-Set up [github/licensed](https://github.com/github/licensed) for use in action workflows, at the specified `version` input and target platform.. The action will install the licensed gem in environments that support rubygems, or an executable when rubygems isn't available.
+Set up [github/licensed](https://github.com/github/licensed) for use in action workflows, at the specified `version` input and target platform.  The action will fail if licensed isn't available for the specified version and target platform.
 
-The action will fail if licensed isn't available for the specified version and target platform.  Licensed is currently supported on macOS and linux platforms.
+## Installing licensed as a Ruby gem
 
-**Note**: When installing a licensed executable, this action will overwrite any version of the executable already installed at the `install-dir` input.
+Installing licensed as a Ruby gem requires an Actions environment that supports `gem install`.  The default system Ruby installation that is available in GitHub Actions runners does not support user-installed gems.  Please use [ruby/setup-ruby](https://github.com/ruby/setup-ruby) or a similar action in your workflow before using this action in order to install licensed as a Ruby gem.
+
+## Installing licensed as an executable
+
+**Licensed is not available as an executable for any version >= 4.0.  Please install licensed as a Ruby gem for these versions**
+
+Licensed executables are provided for macOS and linux platforms.  When installing a licensed executable, this action will overwrite any version of the executable already installed at the `install-dir` input.
+
+Installing licensed as an executable requires making API calls to GitHub which can be rate limited and significantly slow down a GitHub Action workflow run.  Rate limiting is more likely to happen when using `${{ secrets.GITHUB_TOKEN }}` for the `github_token` input or when leaving the `github_token` input empty.  If you are hitting frequent rate limiting and long action runtimes, please set `github_token` to a user PAT or install licensed as a Ruby gem.
 
 ## Usage
 
@@ -15,14 +23,20 @@ list dependencies:
 ```yaml
 steps:
 - uses: actions/checkout@v3
-  with:
-    fetch-depth: 0 # prefer to use a full fetch for licensed workflows
+
+# setup application environment
+- uses: actions/setup-node@v3
+- run: npm install # install dependencies in local environment
+
+# setup ruby environment before running jonabc/setup-licensed
+- uses: ruby/setup-ruby@v1 
+
 - uses: jonabc/setup-licensed@v1
   with:
-    version: '2.x' # required: supports matching based on string equivalence or node-semver range
+    version: '4.x' # required: supports matching based on string equivalence or node-semver range
     install-dir: /path/to/install/at # optional: defaults to /usr/local/bin
     github_token: # optional: allows users to make authenticated requests to GitHub's APIs
-- run: npm install # install dependencies in local environment
+
 - run: licensed list
 ```
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,9 @@ steps:
 - run: npm install # install dependencies in local environment
 
 # setup ruby environment before running jonabc/setup-licensed
-- uses: ruby/setup-ruby@v1 
+- uses: ruby/setup-ruby@v1
+  with:
+    ruby-version: ruby
 
 - uses: jonabc/setup-licensed@v1
   with:


### PR DESCRIPTION
This updates the README and a few of the actions in this repo for the changes in major version 4 of licensed.  Licensed v4+ is no longer released as an executable.  To install licensed as a gem requires first running ruby/setup-ruby.  I also included a note about installing licensed as a gem rather than an executable if the action routinely takes a long time to run from being rate limited by the GitHub API.