### PR TITLE
add CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+# This repository is maintained by:
+* @ajhenry @lumaxis


### PR DESCRIPTION
### Description

Add CODEOWNERS identifying the developers taking primary ownership of the code.  Full ownership is by the ospo-engineering team.